### PR TITLE
Fix for when diff is zero seconds

### DIFF
--- a/src/Time/Distance.elm
+++ b/src/Time/Distance.elm
@@ -85,7 +85,10 @@ inWords posix1 posix2 =
         diffInYearFloat =
             toFloat absDiff / year
     in
-    if diffInSeconds < 25 then
+    if diffInSeconds == 0 then
+        "0 seconds"
+
+    else if diffInSeconds < 25 then
         "less than " ++ toS diffInSeconds ++ " seconds"
 
     else if diffInSeconds < 35 then

--- a/tests/DistanceTest.elm
+++ b/tests/DistanceTest.elm
@@ -242,4 +242,9 @@ suite =
             (posix now)
             (now |> plusYears 3 |> plusMonths 4 |> posix)
             "over 3 years"
+        , inWordsTest
+            "0 seconds"
+            (posix now)
+            (posix now)
+            "0 seconds"
         ]


### PR DESCRIPTION
Before it would say "less than 0 seconds". Now it says "0 seconds".